### PR TITLE
Don't prefix slack room with hash

### DIFF
--- a/src/grafana.coffee
+++ b/src/grafana.coffee
@@ -288,7 +288,7 @@ module.exports = (robot) ->
       filename: filename
       filetype: "auto"
       title: title
-      channels: '#' + msg.message.room
+      channels: msg.message.room
 
     req = request.post uri, (err, res, body) ->
       if (err)


### PR DESCRIPTION
In recent versions of hubot-slack, the API has changed to no longer use
human-readable room names (since these can be renamed), but room IDs
instead. These room IDs do not begin with a hash symbol. This change
broke the upload functionality of hubot-grafana-slack.

This change removes the hash symbol, fixing the issue.